### PR TITLE
added 'promise-polyfill-lite' to main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,10 @@
     "Taylor Hakes"
   ],
   "description": "Lightweight promise polyfill for the browser and node. A+ Compliant.",
-  "main": "Promise.js",
+  "main": [
+    "Promise.js",
+    "promise-polyfill-lite.html"
+  ],
   "moduleType": [
     "globals",
     "node"


### PR DESCRIPTION
The component `promise-polyfill-lite` was added to `main` since other libraries require it as well as the `Promise.js` script, for example [`iron-request`](https://github.com/PolymerElements/iron-ajax/blob/dbe837add7aaacc39a8329abb796bcce2609cb86/iron-request.html#L11)
