### PR TITLE
Fix when base is not available

### DIFF
--- a/promise-polyfill-lite.html
+++ b/promise-polyfill-lite.html
@@ -12,11 +12,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 (function() {
   if (!window.Promise) {
     var asap;
+
     if (window.Polymer) {
-      asap = Polymer.Base.async;
-    } else {
-      asap = setTimeout;
+      // available in polymer 1 or hybrid
+      if (Polymer.Async) {
+        asap = Polymer.Base.async;
+
+      // available in polymer 2
+      } else if (Polymer.Base) {
+        asap = polymer.Async.microtask.run;
+      }
     }
+
+    asap = asap || window.setTimeout;
 
     window.Promise = MakePromise(asap);
   }

--- a/promise-polyfill-lite.html
+++ b/promise-polyfill-lite.html
@@ -15,11 +15,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     if (window.Polymer) {
       // available in polymer 1 or hybrid
-      if (Polymer.Async) {
+      if (Polymer.Base) {
         asap = Polymer.Base.async;
 
       // available in polymer 2
-      } else if (Polymer.Base) {
+      } else if (Polymer.Async) {
         asap = polymer.Async.microtask.run;
       }
     }

--- a/promise-polyfill-lite.html
+++ b/promise-polyfill-lite.html
@@ -20,7 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // available in polymer 2
       } else if (Polymer.Async) {
-        asap = polymer.Async.microtask.run;
+        asap = Polymer.Async.microtask.run;
       }
     }
 


### PR DESCRIPTION
`Polymer.Base` is not available when they import `polymer-element.html`, but `window.Polymer` is. Happens in IE.

Pinging @arthurevans for tracking